### PR TITLE
Add docker image build & push github action

### DIFF
--- a/.github/workflows/publish-docker-image.yml
+++ b/.github/workflows/publish-docker-image.yml
@@ -1,0 +1,44 @@
+name: Publish Docker image
+on:
+  push:
+    branches:
+      - feature/docker-build
+
+env:
+  IMAGE_NAME: demo-microservice
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push'
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Build image
+        run: docker build . --file Dockerfile --tag image
+
+      - name: Log into registry
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login docker.pkg.github.com -u ${{ github.actor }} --password-stdin
+
+      - name: Push image
+        run: |
+          IMAGE_ID=docker.pkg.github.com/${{ github.repository }}/$IMAGE_NAME
+
+          # Change all uppercase to lowercase
+          IMAGE_ID=$(echo $IMAGE_ID | tr '[A-Z]' '[a-z]')
+
+          # Strip git ref prefix from version
+          VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
+
+          # Strip "v" prefix from tag name
+          [[ "${{ github.ref }}" == "refs/tags/"* ]] && VERSION=$(echo $VERSION | sed -e 's/^v//')
+
+          # Use Docker `latest` tag convention
+          [ "$VERSION" == "master" ] && VERSION=latest
+
+          echo IMAGE_ID=$IMAGE_ID
+          echo VERSION=$VERSION
+
+          docker tag image $IMAGE_ID:$VERSION
+          docker push $IMAGE_ID:$VERSION

--- a/.github/workflows/publish-docker-image.yml
+++ b/.github/workflows/publish-docker-image.yml
@@ -1,8 +1,13 @@
 name: Publish Docker image
 on:
   push:
+    # Publish `master` as Docker `latest` image.
     branches:
-      - feature/docker-build
+      - master
+
+    # Publish `v1.2.3` tags as releases.
+    tags:
+      - v*
 
 env:
   IMAGE_NAME: demo-microservice


### PR DESCRIPTION
This is a part of #4 which adds a simple docker build & push github action. As I've not used github actions before I'm committing this as a good starting point before adding additional steps such as automatic version bumping, linting, testing.