### PR TITLE
run inside Docker container as non-root user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,14 @@
 FROM python:3.8
 
-RUN mkdir /app
-WORKDIR /app
-
 # By doing this separately to copying over our code we are able to cache our dependencies.
 # This means that if a subsequent build only changes our code, and not requirements.txt,
 # then we don't need to do a fresh install of all of our dependencies listed in requirements.txt
-COPY requirements.txt requirements.txt
-RUN pip install -r requirements.txt
+COPY requirements.txt /tmp/requirements.txt
+RUN pip install -r /tmp/requirements.txt  --no-cache-dir
+
+RUN useradd --create-home serviceuser
+WORKDIR /home/serviceuser
+USER serviceuser
 
 COPY business business
 COPY config config


### PR DESCRIPTION
Ensures we're not running as a root user, this is recommended for security purposes! Always good to reduce the likelihood of privelege escalation.