### PR TITLE
set version numbers in requirements.txt and fix ModelSchema in location

### DIFF
--- a/business/models/location.py
+++ b/business/models/location.py
@@ -7,7 +7,8 @@ class Location(database.Model):
     name = database.Column(database.String, nullable=False)
 
 
-class LocationSchema(marshmallow.ModelSchema):
+class LocationSchema(marshmallow.SQLAlchemyAutoSchema):
     class Meta:
         model = Location
+        load_instance = True
         sqla_session = database.session

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
-flask
-Flask-SQLAlchemy
-flask-marshmallow
-marshmallow-sqlalchemy
-marshmallow
-dynaconf[yaml]
-gunicorn
+flask==1.1.2
+Flask-SQLAlchemy==2.4.1
+flask-marshmallow==0.12.0
+marshmallow-sqlalchemy==0.23.0
+marshmallow==3.5.1
+dynaconf[yaml]==2.2.3
+gunicorn==20.0.4


### PR DESCRIPTION
This isn't full version pinning, but should at least keep our dependencies compatible, it will need pinning later to ensure that transitive dependencies are also compatible.
There was a deprecation in one of the SQLAlchemy libraries that is in use, this is also fixed in this commit by updating to the new suggested class.
See https://flask-marshmallow.readthedocs.io/en/latest/changelog.html#id2

related to #6 